### PR TITLE
Rebuild for x86_64-apple-darwin20.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,7 @@
 build_parameters:
   - "--suppress-variables"
 
+channels:
+  - rafaelmartins-qt
+
+upload_without_merge: true

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,14 +2,14 @@ cross_target_platform:
   - osx-64     # [x86_64]
   - osx-arm64  # [not x86_64]
 macos_machine:
-  - x86_64-apple-darwin13.4.0  # [x86_64]
+  - x86_64-apple-darwin20.0.0  # [x86_64]
   - arm64-apple-darwin20.0.0   # [not x86_64]
 CBUILD:
   - x86_64-conda-linux-gnu       # [linux64]
   - powerpc64le-conda-linux-gnu  # [linux and ppc64le]
   - aarch64-conda-linux-gnu      # [linux and aarch64]
   - s390x-conda-linux-gnu        # [linux and s390x]
-  - x86_64-apple-darwin13.4.0    # [osx and x86_64]
+  - x86_64-apple-darwin20.0.0    # [osx and x86_64]
   - arm64-apple-darwin20.0.0     # [osx and arm64]
 uname_machine:
   - x86_64  # [x86_64]
@@ -18,12 +18,11 @@ meson_cpu_family:
   - x86_64   # [x86_64]
   - aarch64  # [not x86_64]
 uname_kernel_release:
-  - 13.4.0  # [x86_64]
-  - 20.0.0  # [not x86_64]
+  - 20.0.0
 MACOSX_DEPLOYMENT_TARGET:  # [linux]
   - 10.9                   # [linux]
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-  - _sysconfigdata_x86_64_apple_darwin13_4_0  # [x86_64]
+  - _sysconfigdata_x86_64_apple_darwin20_0_0  # [x86_64]
   - _sysconfigdata_arm64_apple_darwin20_0_0   # [not x86_64]
 zip_keys:
   - - cross_target_platform

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: clang-compiler-activation
@@ -129,18 +129,12 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  license_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/blob/master/LICENSE.txt
   summary: clang compilers for conda-build 3
   doc_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
   dev_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
 
 extra:
-  recipe-maintainers:
-    - isuruf
-    - mingwandroid
-    - katietz
-    - h-vetinari
   skip-lints:
     - missing_description
-    - missing_doc_source_url
     - missing_tests
+    - host_section_needs_exact_pinnings


### PR DESCRIPTION
clang-compiler-activation 14.0.6

**Destination channel:** defaults

### Links

- [PKG-5176](https://anaconda.atlassian.net/browse/PKG-5176) 

### Explanation of changes:

- We need this for qt 6.7 in macos intel machines. The existing x86_64-apple-darwin13.4.0 is not capable of building with the minimal sdk version required for qt 6.7 due to using an old version of tapi.


[PKG-5176]: https://anaconda.atlassian.net/browse/PKG-5176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ