### PR TITLE
Revert upgrade to clang_compiler version 20.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,3 @@
 build_parameters:
   - "--suppress-variables"
 
-channels:
-  - rafaelmartins-qt
-
-upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,6 @@
 build_parameters:
   - "--suppress-variables"
 
+staging_channel_upload_target: clang_revert
+
+upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,7 @@
 build_parameters:
   - "--suppress-variables"
 
-staging_channel_upload_target: clang_revert
+channels: 
+  - danielpetry
 
 upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,7 @@
 build_parameters:
   - "--suppress-variables"
 
-channels: 
+channels:
   - danielpetry
 
 upload_without_merge: true

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,14 +2,14 @@ cross_target_platform:
   - osx-64     # [x86_64]
   - osx-arm64  # [not x86_64]
 macos_machine:
-  - x86_64-apple-darwin20.0.0  # [x86_64]
+  - x86_64-apple-darwin13.4.0  # [x86_64]
   - arm64-apple-darwin20.0.0   # [not x86_64]
 CBUILD:
   - x86_64-conda-linux-gnu       # [linux64]
   - powerpc64le-conda-linux-gnu  # [linux and ppc64le]
   - aarch64-conda-linux-gnu      # [linux and aarch64]
   - s390x-conda-linux-gnu        # [linux and s390x]
-  - x86_64-apple-darwin20.0.0    # [osx and x86_64]
+  - x86_64-apple-darwin13.4.0    # [osx and x86_64]
   - arm64-apple-darwin20.0.0     # [osx and arm64]
 uname_machine:
   - x86_64  # [x86_64]
@@ -18,11 +18,12 @@ meson_cpu_family:
   - x86_64   # [x86_64]
   - aarch64  # [not x86_64]
 uname_kernel_release:
-  - 20.0.0
+  - 13.4.0  # [x86_64]
+  - 20.0.0  # [not x86_64]
 MACOSX_DEPLOYMENT_TARGET:  # [linux]
   - 10.9                   # [linux]
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
-  - _sysconfigdata_x86_64_apple_darwin20_0_0  # [x86_64]
+  - _sysconfigdata_x86_64_apple_darwin13_4_0  # [x86_64]
   - _sysconfigdata_arm64_apple_darwin20_0_0   # [not x86_64]
 zip_keys:
   - - cross_target_platform

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 0 %}
+{% set build_number = 2 %}
 
 package:
   name: clang-compiler-activation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 1 %}
+{% set build_number = 0 %}
 
 package:
   name: clang-compiler-activation
@@ -129,12 +129,18 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
+  license_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/blob/master/LICENSE.txt
   summary: clang compilers for conda-build 3
   doc_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
   dev_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
 
 extra:
+  recipe-maintainers:
+    - isuruf
+    - mingwandroid
+    - katietz
+    - h-vetinari
   skip-lints:
     - missing_description
+    - missing_doc_source_url
     - missing_tests
-    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,18 +129,12 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  license_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/blob/master/LICENSE.txt
   summary: clang compilers for conda-build 3
   doc_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
   dev_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
 
 extra:
-  recipe-maintainers:
-    - isuruf
-    - mingwandroid
-    - katietz
-    - h-vetinari
   skip-lints:
     - missing_description
-    - missing_doc_source_url
     - missing_tests
+    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ build:
 requirements:
   build:
     - cctools_{{ target_platform }}  # [osx]
+    - cctools_{{ target_platform }} =949.0.1=*_25       # [osx and x86_64]
     - libcxx {{ version }}
     - gcc_{{ target_platform }}      # [linux]
     - clang {{ version }}            # [osx]
@@ -33,9 +34,11 @@ outputs:
       - clang {{ version }}
       - llvm-tools {{ version }}
       - cctools_{{ target_platform }}        # [osx]
+      - cctools_{{ target_platform }} =949.0.1=*_25       # [osx and x86_64]
       - cctools_{{ cross_target_platform }}
       - ld64_{{ cross_target_platform }}
       - ld64_{{ target_platform }}           # [osx]
+      - ld64_{{ target_platform }} =530=*_25 # [osx and x86_64]
       # this brings in an extra symlink of ld -> x86_64-apple-darwin13.4.0-ld
       # adding these generated an error w/ libtool: https://github.com/conda-forge/libtool-feedstock/issues/24
       # - ld64     # [cross_target_platform == target_platform]
@@ -57,6 +60,7 @@ outputs:
     requirements:
       build:
         - cctools_{{ target_platform }}   # [osx]
+        - cctools_{{ target_platform }} =949.0.1=*_25       # [osx and x86_64]
       host:
         - clangxx {{ version }}
         - libcxx {{ version }}            # [osx]
@@ -91,11 +95,14 @@ outputs:
     requirements:
       build:
         - cctools_{{ target_platform }}  # [osx]
+        - cctools_{{ target_platform }} =949.0.1=*_25       # [osx and x86_64]
       host:
         - clangxx {{ version }}
         - libcxx {{ version }}           # [cross_target_platform in ("osx-64", "osx-arm64")]
         - cctools_{{ cross_target_platform }}
+        - cctools_{{ cross_target_platform }} =949.0.1=*_25       # [osx and x86_64]
         - ld64_{{ cross_target_platform }}
+        - ld64_{{ cross_target_platform }} =530=*_25 # [osx and x86_64]
         - {{ pin_subpackage('clang_' ~ cross_target_platform, exact=True) }}
         - {{ pin_subpackage('clangxx_' ~ cross_target_platform, exact=True) }}
         # hack to force the solver to work


### PR DESCRIPTION
### Explanation of changes:

- the last update caused issues with the python interpreter package <= 3.9 when compiling extensions. The clang_compiler version is embedded in a certain filename without being expressed in the meta.yaml. Safe and relatively straightforward fix is to revert this now.
- this feedstock has a circular dependency on cctools/ld64. Maybe a recursive rebuild between these two will be needed.