### PR TITLE
Refresh clang bootstrap package

### DIFF
--- a/recipe/activate-clang++.sh
+++ b/recipe/activate-clang++.sh
@@ -49,8 +49,8 @@ function _tc_activation() {
     for thing in "$@"; do
       case "${thing}" in
         *,*)
-          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
-          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          newval="${thing#*,}"
+          thing="${thing%%,*}"
           ;;
         *)
           newval="${tc_prefix}${thing}"
@@ -99,7 +99,7 @@ fi
 
 _tc_activation \
   activate @CHOST@- \
-  clang++ \
+  "CLANGXX,${CXX:-@CHOST@-clang++}" \
   "CXX,${CXX:-@CHOST@-clang++}" \
   "CXX_FOR_BUILD,${CONDA_PREFIX}/bin/@CXX_FOR_BUILD@" \
   "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \

--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -49,8 +49,8 @@ function _tc_activation() {
     for thing in "$@"; do
       case "${thing}" in
         *,*)
-          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
-          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          newval="${thing#*,}"
+          thing="${thing%%,*}"
           ;;
         *)
           newval="${tc_prefix}${thing}"
@@ -133,12 +133,15 @@ _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_RANLIB=${CONDA_PREFIX}/bin/@CHOST@-ranlib -D
 _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_LINKER=${CONDA_PREFIX}/bin/@CHOST@-ld -DCMAKE_STRIP=${CONDA_PREFIX}/bin/@CHOST@-strip"
 _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_INSTALL_NAME_TOOL=${CONDA_PREFIX}/bin/@CHOST@-install_name_tool"
 _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_LIBTOOL=${CONDA_PREFIX}/bin/@CHOST@-libtool"
-_CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
+if [ "${MACOSX_DEPLOYMENT_TARGET:-0}" != "0" ]; then
+  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
+fi
 _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT_TEMP}"
 
-_MESON_ARGS="--buildtype release"
+_MESON_ARGS="-Dbuildtype=release"
 
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
+  _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_FIND_APPBUNDLE=LAST"
   _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
   _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_PROGRAM_PATH=${BUILD_PREFIX}/bin;${PREFIX}/bin"
   _MESON_ARGS="${_MESON_ARGS} --prefix="$PREFIX" -Dlibdir=lib"
@@ -146,30 +149,58 @@ fi
 
 if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
   _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=@UNAME_MACHINE@ -DCMAKE_SYSTEM_VERSION=@UNAME_KERNEL_RELEASE@"
-  _MESON_ARGS="${_MESON_ARGS} --cross-file $BUILD_PREFIX/meson_cross_file.txt"
-  echo "[host_machine]" > $BUILD_PREFIX/meson_cross_file.txt
-  echo "system = 'darwin'" >> $BUILD_PREFIX/meson_cross_file.txt
-  echo "cpu = '@UNAME_MACHINE@'" >> $BUILD_PREFIX/meson_cross_file.txt
-  echo "cpu_family = '@MESON_CPU_FAMILY@'" >> $BUILD_PREFIX/meson_cross_file.txt
-  echo "endian = 'little'" >> $BUILD_PREFIX/meson_cross_file.txt
+  _MESON_ARGS="${_MESON_ARGS} --cross-file ${CONDA_PREFIX}/meson_cross_file.txt"
+  echo "[host_machine]" > ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "system = 'darwin'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "cpu = '@UNAME_MACHINE@'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "cpu_family = '@MESON_CPU_FAMILY@'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "endian = 'little'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  # specify path to correct binaries from build (not host) environment,
+  # which meson will not auto-discover (out of caution) if not told explicitly.
+  echo "[binaries]" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "cmake = '${CONDA_PREFIX}/bin/cmake'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "pkg-config = '${CONDA_PREFIX}/bin/pkg-config'" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  # meson guesses whether it can run binaries in cross-compilation based on some heuristics,
+  # and those can be wrong; see https://mesonbuild.com/Cross-compilation.html#properties
+  echo "[properties]" >> ${CONDA_PREFIX}/meson_cross_file.txt
+  echo "needs_exe_wrapper = true" >> ${CONDA_PREFIX}/meson_cross_file.txt
 fi
 
 _tc_activation \
   activate @CHOST@- "HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_BUILD,@CBUILD@" \
-  ar as checksyms install_name_tool libtool lipo nm nmedit otool \
-  pagestuff ranlib redo_prebinding seg_addr_table seg_hack segedit size strings strip \
-  clang ld \
+  "AR,${AR:-@CHOST@-ar}" \
+  "AS,${AS:-@CHOST@-as}" \
+  "CHECKSYMS,${CHECKSYMS:-@CHOST@-checksyms}" \
+  "INSTALL_NAME_TOOL,${INSTALL_NAME_TOOL:-@CHOST@-install_name_tool}" \
+  "LIBTOOL,${LIBTOOL:-@CHOST@-libtool}" \
+  "LIPO,${LIPO:-@CHOST@-lipo}" \
+  "NM,${NM:-@CHOST@-nm}" \
+  "NMEDIT,${NMEDIT:-@CHOST@-nmedit}" \
+  "OTOOL,${OTOOL:-@CHOST@-otool}" \
+  "PAGESTUFF,${PAGESTUFF:-@CHOST@-pagestuff}" \
+  "RANLIB,${RANLIB:-@CHOST@-ranlib}" \
+  "REDO_PREBINDING,${REDO_PREBINDING:-@CHOST@-redo_prebinding}" \
+  "SEG_ADDR_TABLE,${SEG_ADDR_TABLE:-@CHOST@-seg_addr_table}" \
+  "SEG_HACK,${SEG_HACK:-@CHOST@-seg_hack}" \
+  "SEGEDIT,${SEGEDIT:-@CHOST@-segedit}" \
+  "SIZE,${SIZE:-@CHOST@-size}" \
+  "STRINGS,${STRINGS:-@CHOST@-strings}" \
+  "STRIP,${STRIP:-@CHOST@-strip}" \
+  "CLANG,${CLANG:-@CHOST@-clang}" \
+  "LD,${LD:-@CHOST@-ld}" \
   "CC,${CC:-@CHOST@-clang}" \
   "OBJC,${OBJC:-@CHOST@-clang}" \
+  "CPP,${CPP:-@CHOST@-clang-cpp}" \
   "CC_FOR_BUILD,${CONDA_PREFIX}/bin/@CC_FOR_BUILD@" \
   "OBJC_FOR_BUILD,${CONDA_PREFIX}/bin/@CC_FOR_BUILD@" \
-  "CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
-  "CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
-  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
-  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
-  "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
+  "CPP_FOR_BUILD,${CONDA_PREFIX}/bin/@CPP_FOR_BUILD@" \
+  "CPPFLAGS,${CPPFLAGS_USED}${CPPFLAGS:+ }${CPPFLAGS:-}" \
+  "CFLAGS,${CFLAGS_USED}${CFLAGS:+ }${CFLAGS:-}" \
+  "LDFLAGS,${LDFLAGS_USED}${LDFLAGS:+ }${LDFLAGS:-}" \
+  "LDFLAGS_LD,${LDFLAGS_LD_USED}${LDFLAGS_LD:+ }${LDFLAGS_LD:-}" \
+  "DEBUG_CFLAGS,${DEBUG_CFLAGS_USED}${DEBUG_CFLAGS:+ }${DEBUG_CFLAGS:-}" \
   "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_PYTHON_SYSCONFIGDATA_NAME@}" \
   "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH:-${CMAKE_PREFIX_PATH_USED}}" \
   "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,19 +3,16 @@
 CHOST=${macos_machine}
 
 FINAL_CPPFLAGS="-D_FORTIFY_SOURCE=2"
-FINAL_CFLAGS="-ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe"
-FINAL_CXXFLAGS="-ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
-if [[ "${version}" == "11.1.0" ]]; then
-  FINAL_CXXFLAGS="${FINAL_CXXFLAGS} -std=c++14"
-fi
+FINAL_CFLAGS="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe"
+FINAL_CXXFLAGS="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
 if [[ "${uname_machine}" == "x86_64" ]]; then
   FINAL_CFLAGS="-march=core2 -mtune=haswell -mssse3 $FINAL_CFLAGS"
   FINAL_CXXFLAGS="-march=core2 -mtune=haswell -mssse3 $FINAL_CXXFLAGS"
 fi
 # These are the LDFLAGS for when the linker is being driven by a compiler, i.e. with -Wl,
-FINAL_LDFLAGS="-Wl,-pie -Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs"
+FINAL_LDFLAGS="-Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs"
 # These are the LDFLAGS for when the linker is being called directly, i.e. without -Wl,
-FINAL_LDFLAGS_LD="-pie -headerpad_max_install_names -dead_strip_dylibs"
+FINAL_LDFLAGS_LD="-headerpad_max_install_names -dead_strip_dylibs"
 FINAL_DEBUG_CFLAGS="-Og -g -Wall -Wextra"
 FINAL_DEBUG_CXXFLAGS="-Og -g -Wall -Wextra"
 
@@ -27,9 +24,11 @@ fi
 
 if [[ "$target_platform" == linux* ]]; then
   CC_FOR_BUILD=${CBUILD}-gcc
+  CPP_FOR_BUILD=${CBUILD}-cpp
   CXX_FOR_BUILD=${CBUILD}-g++
 else
   CC_FOR_BUILD=${CBUILD}-clang
+  CPP_FOR_BUILD=${CBUILD}-clang-cpp
   CXX_FOR_BUILD=${CBUILD}-clang++
 fi
 
@@ -39,6 +38,7 @@ find . -name "*activate*.sh" -exec sed -i.bak "s|@CHOST@|${CHOST}|g" "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@CBUILD@|${CBUILD}|g" "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@CPPFLAGS@|${FINAL_CPPFLAGS}|g"             "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@CC_FOR_BUILD@|${CC_FOR_BUILD}|g"           "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@CPP_FOR_BUILD@|${CPP_FOR_BUILD}|g"         "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@CXX_FOR_BUILD@|${CXX_FOR_BUILD}|g"         "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@CFLAGS@|${FINAL_CFLAGS}|g"                 "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@DEBUG_CFLAGS@|${FINAL_DEBUG_CFLAGS}|g"     "{}" \;
@@ -51,6 +51,6 @@ find . -name "*activate*.sh" -exec sed -i.bak "s|@CONDA_BUILD_CROSS_COMPILATION@
 find . -name "*activate*.sh" -exec sed -i.bak "s|@_PYTHON_SYSCONFIGDATA_NAME@|${FINAL_PYTHON_SYSCONFIGDATA_NAME}|g"  "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@UNAME_MACHINE@|${uname_machine}|g"         "{}" \;
 find . -name "*activate*.sh" -exec sed -i.bak "s|@MESON_CPU_FAMILY@|${meson_cpu_family}|g"         "{}" \;
-find . -name "*activate*.sh" -exec sed -i.bak "s|@UNAME_KERNEL_RELEASE@|${uname_kernel_release}|g"         "{}" \;
-find . -name "*activate*.sh" -exec sed -i.bak "s|@TARGET_PLATFORM@|${cross_target_platform}|g"         "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@UNAME_KERNEL_RELEASE@|${uname_kernel_release}|g" "{}" \;
+find . -name "*activate*.sh" -exec sed -i.bak "s|@TARGET_PLATFORM@|${cross_target_platform}|g"     "{}" \;
 find . -name "*activate*.sh.bak" -exec rm "{}" \;

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -32,7 +32,8 @@ FINAL_PYTHON_SYSCONFIGDATA_NAME:
   - _sysconfigdata_x86_64_apple_darwin13_4_0  # [x86_64]
   - _sysconfigdata_arm64_apple_darwin20_0_0   # [not x86_64]
 zip_keys:
-  - - cross_target_platform
+  -
+    - cross_target_platform
     - macos_machine
     - meson_cpu_family
     - uname_machine

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,3 @@
-cross_target_platform:
-  - osx-64     # [x86_64]
-  - osx-arm64  # [not x86_64]
-macos_machine:
-  - x86_64-apple-darwin13.4.0  # [x86_64]
-  - arm64-apple-darwin20.0.0   # [not x86_64]
 CBUILD:
   - x86_64-conda-linux-gnu       # [linux64]
   - powerpc64le-conda-linux-gnu  # [linux and ppc64le]
@@ -11,6 +5,20 @@ CBUILD:
   - s390x-conda-linux-gnu        # [linux and s390x]
   - x86_64-apple-darwin13.4.0    # [osx and x86_64]
   - arm64-apple-darwin20.0.0     # [osx and arm64]
+
+MACOSX_DEPLOYMENT_TARGET:  # [linux]
+  - 10.9                   # [linux]
+
+version:
+  - 14.0.6
+#  - 17.0.6 SOON!!!!
+
+cross_target_platform:
+  - osx-64     # [x86_64]
+  - osx-arm64  # [not x86_64]
+macos_machine:
+  - x86_64-apple-darwin13.4.0  # [x86_64]
+  - arm64-apple-darwin20.0.0   # [not x86_64]
 uname_machine:
   - x86_64  # [x86_64]
   - arm64   # [not x86_64]
@@ -20,8 +28,6 @@ meson_cpu_family:
 uname_kernel_release:
   - 13.4.0  # [x86_64]
   - 20.0.0  # [not x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [linux]
-  - 10.9                   # [linux]
 FINAL_PYTHON_SYSCONFIGDATA_NAME:
   - _sysconfigdata_x86_64_apple_darwin13_4_0  # [x86_64]
   - _sysconfigdata_arm64_apple_darwin20_0_0   # [not x86_64]
@@ -32,5 +38,4 @@ zip_keys:
     - uname_machine
     - uname_kernel_release
     - FINAL_PYTHON_SYSCONFIGDATA_NAME
-version:
-  - 14.0.6
+

--- a/recipe/deactivate-clang++.sh
+++ b/recipe/deactivate-clang++.sh
@@ -49,8 +49,8 @@ function _tc_activation() {
     for thing in "$@"; do
       case "${thing}" in
         *,*)
-          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
-          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          newval="${thing#*,}"
+          thing="${thing%%,*}"
           ;;
         *)
           newval="${tc_prefix}${thing}"
@@ -100,7 +100,7 @@ fi
 
 _tc_activation \
   deactivate @CHOST@- \
-  clang++ \
+  "CLANGXX,${CXX:-@CHOST@-clang++}" \
   "CXX,${CXX:-@CHOST@-clang++}" \
   "CXX_FOR_BUILD,${CONDA_PREFIX}/bin/@CXX_FOR_BUILD@" \
   "CXXFLAGS,${CXXFLAGS:-${CXXFLAGS_USED}}" \

--- a/recipe/deactivate-clang.sh
+++ b/recipe/deactivate-clang.sh
@@ -49,8 +49,8 @@ function _tc_activation() {
     for thing in "$@"; do
       case "${thing}" in
         *,*)
-          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
-          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          newval="${thing#*,}"
+          thing="${thing%%,*}"
           ;;
         *)
           newval="${tc_prefix}${thing}"
@@ -127,18 +127,37 @@ _tc_activation \
   deactivate @CHOST@- "HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_HOST,@CHOST@" \
   "CONDA_TOOLCHAIN_BUILD,@CBUILD@" \
-  ar as checksyms install_name_tool libtool lipo nm nmedit otool \
-  pagestuff ranlib redo_prebinding seg_addr_table seg_hack segedit size strings strip \
-  clang ld \
+  "AR,${AR:-@CHOST@-ar}" \
+  "AS,${AS:-@CHOST@-as}" \
+  "CHECKSYMS,${CHECKSYMS:-@CHOST@-checksyms}" \
+  "INSTALL_NAME_TOOL,${INSTALL_NAME_TOOL:-@CHOST@-install_name_tool}" \
+  "LIBTOOL,${LIBTOOL:-@CHOST@-libtool}" \
+  "LIPO,${LIPO:-@CHOST@-lipo}" \
+  "NM,${NM:-@CHOST@-nm}" \
+  "NMEDIT,${NMEDIT:-@CHOST@-nmedit}" \
+  "OTOOL,${OTOOL:-@CHOST@-otool}" \
+  "PAGESTUFF,${PAGESTUFF:-@CHOST@-pagestuff}" \
+  "RANLIB,${RANLIB:-@CHOST@-ranlib}" \
+  "REDO_PREBINDING,${REDO_PREBINDING:-@CHOST@-redo_prebinding}" \
+  "SEG_ADDR_TABLE,${SEG_ADDR_TABLE:-@CHOST@-seg_addr_table}" \
+  "SEG_HACK,${SEG_HACK:-@CHOST@-seg_hack}" \
+  "SEGEDIT,${SEGEDIT:-@CHOST@-segedit}" \
+  "SIZE,${SIZE:-@CHOST@-size}" \
+  "STRINGS,${STRINGS:-@CHOST@-strings}" \
+  "STRIP,${STRIP:-@CHOST@-strip}" \
+  "CLANG,${CLANG:-@CHOST@-clang}" \
+  "LD,${LD:-@CHOST@-ld}" \
   "CC,${CC:-@CHOST@-clang}" \
   "OBJC,${OBJC:-@CHOST@-clang}" \
+  "CPP,${CPP:-@CHOST@-clang-cpp}" \
   "CC_FOR_BUILD,${CONDA_PREFIX}/bin/@CC_FOR_BUILD@" \
   "OBJC_FOR_BUILD,${CONDA_PREFIX}/bin/@OBJC_FOR_BUILD@" \
-  "CPPFLAGS,${CPPFLAGS:-${CPPFLAGS_USED}}" \
-  "CFLAGS,${CFLAGS:-${CFLAGS_USED}}" \
-  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
-  "LDFLAGS_LD,${LDFLAGS_LD:-${LDFLAGS_LD_USED}}" \
-  "DEBUG_CFLAGS,${DEBUG_CFLAGS:-${DEBUG_CFLAGS_USED}}" \
+  "CPP_FOR_BUILD,${CONDA_PREFIX}/bin/@CPP_FOR_BUILD@" \
+  "CPPFLAGS,${CPPFLAGS_USED}${CPPFLAGS:+ }${CPPFLAGS:-}" \
+  "CFLAGS,${CFLAGS_USED}${CFLAGS:+ }${CFLAGS:-}" \
+  "LDFLAGS,${LDFLAGS_USED}${LDFLAGS:+ }${LDFLAGS:-}" \
+  "LDFLAGS_LD,${LDFLAGS_LD_USED}${LDFLAGS_LD:+ }${LDFLAGS_LD:-}" \
+  "DEBUG_CFLAGS,${DEBUG_CFLAGS_USED}${DEBUG_CFLAGS:+ }${DEBUG_CFLAGS:-}" \
   "_CONDA_PYTHON_SYSCONFIGDATA_NAME,${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_PYTHON_SYSCONFIGDATA_NAME@}" \
   "CMAKE_PREFIX_PATH,${CMAKE_PREFIX_PATH:-${CMAKE_PREFIX_PATH_USED}}" \
   "CONDA_BUILD_CROSS_COMPILATION,@CONDA_BUILD_CROSS_COMPILATION@" \

--- a/recipe/install-clang.sh
+++ b/recipe/install-clang.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 
 set -e -x
-
-CHOST=${macos_machine}
-
 mkdir -p "${PREFIX}"/etc/conda/{de,}activate.d/
 cp "${SRC_DIR}"/activate-clang.sh "${PREFIX}"/etc/conda/activate.d/activate_"${PKG_NAME}".sh
 cp "${SRC_DIR}"/deactivate-clang.sh "${PREFIX}"/etc/conda/deactivate.d/deactivate_"${PKG_NAME}".sh
-
-pushd "${PREFIX}"/bin
-  ln -s clang ${CHOST}-clang
-  if [[ "${CBUILD}" != ${CHOST} ]]; then
-    ln -s clang ${CBUILD}-clang
-  fi
-popd

--- a/recipe/install-clang_impl.sh
+++ b/recipe/install-clang_impl.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -x
+
+CHOST=${macos_machine}
+
+pushd "${PREFIX}"/bin
+  ln -s clang ${CHOST}-clang
+  ln -s clang-cpp ${CHOST}-clang-cpp
+  if [[ "${CBUILD}" != ${CHOST} ]] && [[ "${target_platform}" != linux-* || ( ${version} != "17.0.6" && ${version} != "18.1.8") ]]; then
+    # before v19.1.1, `clang` on linux already had this symlink, see
+    # https://github.com/conda-forge/clangdev-feedstock/pull/322
+    ln -s clang ${CBUILD}-clang
+    ln -s clang-cpp ${CBUILD}-clang-cpp
+  fi
+popd

--- a/recipe/install-clangxx.sh
+++ b/recipe/install-clangxx.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 
 set -e -x
-
-CHOST=${macos_machine}
-echo CHOST is ${CHOST}
-
 mkdir -p "${PREFIX}"/etc/conda/{de,}activate.d/
 cp "${SRC_DIR}"/activate-clang++.sh "${PREFIX}"/etc/conda/activate.d/activate_"${PKG_NAME}".sh
 cp "${SRC_DIR}"/deactivate-clang++.sh "${PREFIX}"/etc/conda/deactivate.d/deactivate_"${PKG_NAME}".sh
-
-pushd "${PREFIX}"/bin
-  ln -s clang++ ${CHOST}-clang++
-  if [[ "${CHOST}" != "${CBUILD}" ]]; then
-    ln -s clang++ ${CBUILD}-clang++
-  fi
-popd

--- a/recipe/install-clangxx_impl.sh
+++ b/recipe/install-clangxx_impl.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e -x
+
+CHOST=${macos_machine}
+echo CHOST is ${CHOST}
+
+pushd "${PREFIX}"/bin
+  ln -s clang++ ${CHOST}-clang++
+  if [[ "${CBUILD}" != ${CHOST} ]] && [[ "${target_platform}" != linux-* || ( ${version} != "17.0.6" && ${version} != "18.1.8") ]]; then
+    # before v19.1.1, `clangxx` on linux already had this symlink, see
+    # https://github.com/conda-forge/clangdev-feedstock/pull/322
+    ln -s clang++ ${CBUILD}-clang++
+  fi
+popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,11 @@
 {% set version = "14.0.6" %}
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
+# in the past we've had to uncouple the compiler version from the version
+# of the C++ stdlib; keep the variable in case this happens again
+{% set libcxx_major = major_ver %}
 
-{% set build_number = 0 %}
+{% set build_number = 5 %}
 
 package:
   name: clang-compiler-activation
@@ -16,7 +19,7 @@ package:
 #   sha256: 326335a830f2e32d06d0a36393b5455d17dc73e0bd1211065227ee014f92cbf8  # [version == "13.0.1"]
 
 build:
-  skip: true  # [win or linux]
+  # skip: true  # [win or linux]
   number: {{ build_number }}
 
 requirements:
@@ -27,8 +30,8 @@ requirements:
     - clang {{ version }}            # [osx]
 
 outputs:
-  - name: clang_{{ cross_target_platform }}
-    script: install-clang.sh
+  - name: clang_impl_{{ cross_target_platform }}
+    script: install-clang_impl.sh
     requirements:
       - clang {{ version }}
       - llvm-tools {{ version }}
@@ -50,24 +53,38 @@ outputs:
     test:
       commands:
         - {{ CBUILD }}-clang --version
+        - {{ CBUILD }}-clang-cpp --version
         - {{ macos_machine }}-clang --version
+        - {{ macos_machine }}-clang-cpp --version
 
-  - name: clangxx_{{ cross_target_platform }}
-    script: install-clangxx.sh
+  - name: clang_{{ cross_target_platform }}
+    script: install-clang.sh
+    requirements:
+      run:
+        - {{ pin_subpackage("clang_impl_" ~ cross_target_platform, exact=True) }}
+    test:
+      commands:
+        - ${CC} --version
+        - ${CPP} --version
+        - ${CC_FOR_BUILD} --version
+        - ${CPP_FOR_BUILD} --version
+
+  - name: clangxx_impl_{{ cross_target_platform }}
+    script: install-clangxx_impl.sh
     requirements:
       build:
         - cctools_{{ target_platform }}   # [osx]
       host:
         - clangxx {{ version }}
         - libcxx {{ version }}            # [osx]
-        - {{ pin_subpackage('clang_' ~ cross_target_platform, exact=True) }}
+        - {{ pin_subpackage('clang_impl_' ~ cross_target_platform, exact=True) }}
         - gxx_impl_{{ target_platform }}  # [linux]
         # hack to force the solver to work
         - libllvm{{ major_ver }} {{ version }}
       run:
         - clangxx {{ version }}
         # This is not needed in Linux for cross-compiling in a conda-build env, but is needed outside
-        - libcxx >={{ version }}
+        - libcxx >={{ libcxx_major }}
         - {{ pin_subpackage('clang_' ~ cross_target_platform, exact=True) }}
         - gxx_impl_{{ target_platform }}  # [linux]
     # Since transitive run_exports are not currently possible
@@ -86,6 +103,23 @@ outputs:
         - {{ CBUILD }}-clang++ --version
         - {{ macos_machine }}-clang++ --version
 
+  - name: clangxx_{{ cross_target_platform }}
+    script: install-clangxx.sh
+    build:
+      # Since transitive run_exports are not currently possible
+      # (here I would like the run dependency on clangxx to pull in the run_exports from it).
+      run_exports:
+        strong:
+          - libcxx >={{ libcxx_major }}
+    requirements:
+      run:
+        - {{ pin_subpackage("clangxx_impl_" ~ cross_target_platform, exact=True) }}
+        - {{ pin_subpackage("clang_" ~ cross_target_platform, exact=True) }}
+    test:
+      commands:
+        - ${CXX} --version
+        - ${CXX_FOR_BUILD} --version
+
   - name: clang_bootstrap_{{ cross_target_platform }}
     script: install-clang-bootstrap.sh
     requirements:
@@ -93,7 +127,7 @@ outputs:
         - cctools_{{ target_platform }}  # [osx]
       host:
         - clangxx {{ version }}
-        - libcxx {{ version }}           # [cross_target_platform in ("osx-64", "osx-arm64")]
+        - libcxx {{ libcxx_major }}      # [cross_target_platform in ("osx-64", "osx-arm64")]
         - cctools_{{ cross_target_platform }}
         - ld64_{{ cross_target_platform }}
         - {{ pin_subpackage('clang_' ~ cross_target_platform, exact=True) }}
@@ -116,6 +150,7 @@ outputs:
     test:
       commands:
         - {{ macos_machine }}-clang --version
+        - {{ macos_machine }}-clang-cpp --version
         - {{ macos_machine }}-clang++ --version
     about:
       home: https://llvm.org
@@ -125,22 +160,14 @@ outputs:
       summary: clang compiler components in one package for bootstrapping clang
 
 about:
-  home: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
+  home: http://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  license_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/blob/master/LICENSE.txt
   summary: clang compilers for conda-build 3
-  doc_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
-  dev_url: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
 
 extra:
   recipe-maintainers:
     - isuruf
-    - mingwandroid
     - katietz
     - h-vetinari
-  skip-lints:
-    - missing_description
-    - missing_doc_source_url
-    - missing_tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -160,11 +160,13 @@ outputs:
       summary: clang compiler components in one package for bootstrapping clang
 
 about:
-  home: http://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
+  home: https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
   summary: clang compilers for conda-build 3
+  dev_url: https://github.com/llvm/llvm-project
+  doc_url: https://llvm.org/docs/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 # of the C++ stdlib; keep the variable in case this happens again
 {% set libcxx_major = major_ver %}
 
-{% set build_number = 5 %}
+{% set build_number = 6 %}
 
 package:
   name: clang-compiler-activation


### PR DESCRIPTION
clang-bootstrap
- This is the first step of the stage0 rebuild of the llvm/clang compiler stack.

**Destination channel:** defaults

### Links

- [PKG-5928](https://anaconda.atlassian.net/browse/PKG-5928)

### Explanation of changes:
- pull in changes from conda-forge to split impl
- modernize build setup

[PKG-5928]: https://anaconda.atlassian.net/browse/PKG-5928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ