### PR TITLE
Fix/include paths

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,7 @@
 # the conda build parameters to use
 build_parameters:
   - "--suppress-variables"
+  - "--skip-existing"
 
 
 staging_channel_upload_target: llvm-17.0.6-verify-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
 # the conda build parameters to use
 build_parameters:
   - "--suppress-variables"
-  - "-c https://staging.continuum.io/prefect/llvm-17.0.6-stage2-attempt-4"

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
-
-
-staging_channel_upload_target: llvm-17.0.6-verify-2
-channels:
-  - llvm-17.0.6-verify-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,8 @@
 # the conda build parameters to use
 build_parameters:
   - "--suppress-variables"
+
+
+staging_channel_upload_target: llvm-17.0.6-verify-2
+channels:
+  - llvm-17.0.6-verify-2

--- a/recipe/activate-clang++.sh
+++ b/recipe/activate-clang++.sh
@@ -83,7 +83,7 @@ function activate_clangxx() {
 # When people are using conda-build, assume that adding rpath during build, and pointing at
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
-  CXXFLAGS_USED="@CXXFLAGS@ -isystem ${CONDA_BUILD_SYSROOT}/usr/include -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
+  CXXFLAGS_USED="@CXXFLAGS@ -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
   DEBUG_CXXFLAGS_USED="@CXXFLAGS@ @DEBUG_CXXFLAGS@ -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
 else
   CXXFLAGS_USED="@CXXFLAGS@ -isystem ${CONDA_PREFIX}/include"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,8 +4,7 @@ CHOST=${macos_machine}
 
 FINAL_CPPFLAGS="-D_FORTIFY_SOURCE=2"
 FINAL_CFLAGS="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe"
-# TODO revisit this in llvm19 and see if we can remove -isystem \$PREFIX/include/c++/v1. -stdlib=libc++ should be sufficient. It is currently not likely due to the version of cctools and ld64 for mac not being optimal for llvm17. 
-FINAL_CXXFLAGS="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -isystem \$PREFIX/include/c++/v1 -fvisibility-inlines-hidden -fmessage-length=0"
+FINAL_CXXFLAGS="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
 if [[ "${uname_machine}" == "x86_64" ]]; then
   FINAL_CFLAGS="-march=core2 -mtune=haswell -mssse3 $FINAL_CFLAGS"
   FINAL_CXXFLAGS="-march=core2 -mtune=haswell -mssse3 $FINAL_CXXFLAGS"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 
 {% set last_major = "17" %}
 


### PR DESCRIPTION
clang-compiler-activation

**Destination channel:**  defaults

### Explanation of changes:

- Remove incorrect `-isystem` entries in CXXFLAGS 
- Bump build number
- Add back skip-existing and remove the staging channel no longer needed. 
