### PR TITLE
PKG-12730

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,8 +2,4 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-
 aggregate_check: false

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,8 @@
 CHOST=${macos_machine}
 
 FINAL_CPPFLAGS="-D_FORTIFY_SOURCE=2"
+FINAL_CPPFLAGS="$FINAL_CPPFLAGS -DNDEBUG"
+
 FINAL_CFLAGS="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe"
 FINAL_CXXFLAGS="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
 if [[ "${uname_machine}" == "x86_64" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 {% set last_major = "21" %}
 


### PR DESCRIPTION


clang-compiler-activation v21.1.8 rebuild

**Destination channel:** defaults

### Links

- [PKG-12729](https://anaconda.atlassian.net/browse/PKG-12729)


### Related PR
- https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/25


### Explanation of changes:

- set `-DNDEBUG` in our compiler toolchain on osx-*. To prevent causes unnecessary noise in our libraries, like assert statements not being stripped, etc.


[PKG-12729]: https://anaconda.atlassian.net/browse/PKG-12729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ