### PR TITLE
clang-compiler-activation 21.1.8 

### DIFF
--- a/recipe/activate-clang++.sh
+++ b/recipe/activate-clang++.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/activate-clang.sh
+++ b/recipe/activate-clang.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-clang++.sh
+++ b/recipe/deactivate-clang++.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-clang.sh
+++ b/recipe/deactivate-clang.sh
@@ -62,8 +62,8 @@ function _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% endif %}
 {% set major_ver = version.split(".")[0] %}
 
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 
 {% set last_major = "21" %}
 


### PR DESCRIPTION
clang-compiler-activation 21.1.8 

**Destination channel:** Defaults

### Links

- [PKG-12890]
- dev_url:        skipped/tree/
- conda_forge:    https://github.com/conda-forge/clang-compiler-activation-feedstock
- pypi:           https://pypi.org/project/clang-compiler-activation/21.1.8
- pypi inspector: https://inspector.pypi.io/project/clang-compiler-activation/21.1.8

### Explanation of changes:

- conda 26.1.0 changes how activation scripts are run -- now altogether
- this is a preventative change as no other activation/post-link scripts that are likely to interact with clang are known to have `set -u` statements
- see https://github.com/AnacondaRecipes/binutils-feedstock/pull/8 and https://github.com/AnacondaRecipes/ctng-compiler-activation-feedstock/pull/8


[PKG-12890]: https://anaconda.atlassian.net/browse/PKG-12890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ